### PR TITLE
Reproducing Eclipse resources handling error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
 
     <properties>
         <evrete.version>3.2.00</evrete.version>
-    </properties>
+   <maven.compiler.source>17</maven.compiler.source>
+   <maven.compiler.target>17</maven.compiler.target>
+ </properties>
 
 </project>

--- a/src/main/java/com/baeldung/evrete/introduction/IntroductionAJRException.java
+++ b/src/main/java/com/baeldung/evrete/introduction/IntroductionAJRException.java
@@ -1,0 +1,44 @@
+package com.baeldung.evrete.introduction;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+
+import org.evrete.KnowledgeService;
+import org.evrete.api.Knowledge;
+
+import com.baeldung.evrete.introduction.model.Customer;
+import com.baeldung.evrete.introduction.model.Invoice;
+
+public class IntroductionAJRException {
+
+    public static void main(String[] args) throws IOException {
+        ClassLoader classLoader = IntroductionAJRException.class.getClassLoader();
+        KnowledgeService service = new KnowledgeService();
+        URL rulesetUrl = classLoader.getResource("com/baeldung/evrete/introduction/model/SalesRulesetException.java");
+        Knowledge knowledge = service.newKnowledge("JAVA-SOURCE", rulesetUrl);
+
+        List<Customer> customers = Arrays.asList(new Customer("Customer A"), new Customer("Customer B"),
+                new Customer("Customer C"));
+
+        Random random = new Random();
+        Collection<Object> sessionData = new LinkedList<>(customers);
+        for (int i = 0; i < 100_000; i++) {
+            Customer randomCustomer = customers.get(random.nextInt(customers.size()));
+            Invoice invoice = new Invoice(randomCustomer, 100 * random.nextDouble());
+            sessionData.add(invoice);
+        }
+
+        knowledge.newStatelessSession().insert(sessionData).fire();
+
+        for (Customer c : customers) {
+            System.out.printf("%s:\t$%,.2f%n", c.getName(), c.getTotal());
+        }
+
+        service.shutdown();
+    }
+}

--- a/src/main/resources/com/baeldung/evrete/introduction/model/SalesRulesetException.java
+++ b/src/main/resources/com/baeldung/evrete/introduction/model/SalesRulesetException.java
@@ -1,0 +1,20 @@
+package com.baeldung.evrete.introduction.model;
+
+import com.baeldung.evrete.introduction.model.Customer;
+import com.baeldung.evrete.introduction.model.Invoice;
+import org.evrete.dsl.annotation.Rule;
+import org.evrete.dsl.annotation.Where;
+
+public class SalesRuleset {
+
+    @Rule
+    public void rule1(Customer $c) {
+        $c.setTotal(0.0);
+    }
+
+    @Rule
+    @Where("$i.customer == $c")
+    public void rule2(Customer $c, Invoice $i) {
+        $c.addToTotal($i.getAmount());
+    }
+}


### PR DESCRIPTION
If all resources are Excluded in Eclipse then the Exception example will *not* throw any exceptions. If the resources are not excluded then it will throw Exception in thread "main" java.util.NoSuchElementException: No type registered with variable '$i'.